### PR TITLE
Resolve deprecation warning for wordpress 4.7+

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a workaround to allow sorting the sites based on categories.
 There's a filter being applied (except in the sites screen) that tells WordPress that the site is **not mature**:
 ```
 if( 'sites.php' != $pagenow )
-    add_filter( 'blog_details', array( $this, 'hack_mature_queries' ) );	
+    add_filter( 'site_details', array( $this, 'hack_mature_queries' ) );	
 public function hack_mature_queries( $details )
 {
     $details->mature = 0;

--- a/inc/class-sites-categories-signup.php
+++ b/inc/class-sites-categories-signup.php
@@ -58,11 +58,11 @@ class B5F_Sites_Categories_Signup
         $new_field_value = '';
 
         # Site added in the back end
-        if( !empty( $_POST['blog']['input_site_cat'] ) )
+        if( !empty( $_POST['input_site_cat'] ) )
         {
             switch_to_blog( $blog_id );
             
-            $cat_id = $_POST['blog']['input_site_cat'];
+            $cat_id = $_POST['input_site_cat'];
             
             # debug
             do_action( 'add_debug_info', $cat_id, $label );

--- a/inc/class-sites-categories-signup.php
+++ b/inc/class-sites-categories-signup.php
@@ -61,7 +61,12 @@ class B5F_Sites_Categories_Signup
         if( !empty( $_POST['blog']['input_site_cat'] ) )
         {
             switch_to_blog( $blog_id );
+            
             $cat_id = $_POST['blog']['input_site_cat'];
+            
+            # debug
+            do_action( 'add_debug_info', $cat_id, $label );
+            
             # TODO: if Sign-up is to be enabled, change this to a method
             $val = B5F_Multisite_Categories::get_instance()->do_mature_to_name( $cat_id );
             update_blog_option( $blog_id, 'site_category', $val );

--- a/js/msc-dropdown.js
+++ b/js/msc-dropdown.js
@@ -9,7 +9,7 @@
  */
 
 // UNUSED TEXT FIELD
-// var b5f_add_field = '<input class="regular-text" type="text" title="Site Category" name="blog[site_category]">';
+//~ var b5f_add_field = '<input class="regular-text" type="text" title="Site Category" name="blog[site_category]">';
 
 // Common opening for new fields
 var b5f_open_tr = '<tr class="form-field form-required"></tr>';

--- a/multisite-site-category.php
+++ b/multisite-site-category.php
@@ -176,7 +176,7 @@ class B5F_Multisite_Categories
         
         # WP, ALL MATURES ARE OK
         if( 'sites.php' != $pagenow )
-            add_filter( 'blog_details', array( $this, 'hack_mature_queries' ) );	
+            add_filter( 'site_details', array( $this, 'hack_mature_queries' ) );	
 
         # BAIL OUT
         if( !is_network_admin() )

--- a/multisite-site-category.php
+++ b/multisite-site-category.php
@@ -8,7 +8,7 @@
  * Original author: Rodolfo Buaiz
  * Maintainer: Trinh Nguyen
  * Maintainer URI: http://me.dangtrinh.com
- * Version: 10.001
+ * Version: 2015.05.18
  * License: GPLv2 or later
  * 
  */

--- a/multisite-site-category.php
+++ b/multisite-site-category.php
@@ -282,7 +282,7 @@ HTML;
     public function get_dropdown( $site_id )
     {
         $all_cats = get_option( self::$option_name );
-        $dropdown = '<select name="blog[input_site_cat]" id="input_site_cat">';
+        $dropdown = '<select name="input_site_cat" id="input_site_cat">';
         $site_cat = !empty( $site_id ) ? get_blog_option( $site_id, 'site_category' ) : false;
         $empty_cat = '';
         if( $site_cat )

--- a/multisite-site-category.php
+++ b/multisite-site-category.php
@@ -6,8 +6,8 @@
  * Description: Add a custom meta option when registering new sites in WordPress Multisite.
  * Network: true
  * Original author: Rodolfo Buaiz
- * Maintainer: Trinh Nguyen
- * Maintainer URI: http://me.dangtrinh.com
+ * Author: Trinh Nguyen
+ * Author URI: http://me.dangtrinh.com
  * Version: 2015.05.18
  * License: GPLv2 or later
  * Network: True

--- a/multisite-site-category.php
+++ b/multisite-site-category.php
@@ -173,9 +173,6 @@ class B5F_Multisite_Categories
         require_once 'inc/class-sites-categories-signup.php';
         new B5F_Sites_Categories_Signup();
         
-		//~ if( !is_admin() ){
-			//~ add_action('signup_blogform', array( $this, 'signup_blogform_extra_field' ));
-		//~ }
         
         # WP, ALL MATURES ARE OK
         if( 'sites.php' != $pagenow )
@@ -206,10 +203,6 @@ class B5F_Multisite_Categories
         );
         # Workaround to remove the suffix "-master" from the unzipped directory
         add_filter( 'upgrader_source_selection', array( $this, 'rename_github_zip' ), 1, 3 );
-        
-		//~ add_action('wpmu_new_blog', array( $this, 'add_new_blog_field' ));
-		//~ add_filter('add_signup_meta', array( $this, 'append_extra_field_as_meta'));
-		
     }
 
 
@@ -221,63 +214,6 @@ class B5F_Multisite_Categories
      */
     public function __construct() {}
 
-
-     /**
-	* Add new option when registering a site (back and front end)
-	*
-	* URI: http://stackoverflow.com/a/10372861/1287812
-	*/
-	//~ public function add_new_blog_field( $blog_id, $user_id, $domain, $path, $site_id, $meta )
-	//~ {
-		//~ $new_field_value = 'default';
-	//~ 
-		//~ // Site added in the back end
-		//~ if( !empty( $_POST['blog']['site_category'] ) )
-		//~ {
-			//~ switch_to_blog( $blog_id );
-			//~ $new_field_value = $_POST['blog']['site_category'];
-			//~ update_option( 'site_category', $new_field_value );
-		//~ 
-			//~ restore_current_blog();
-		//~ }
-		//~ // Site added in the front end
-		//~ elseif( !empty( $meta['site_category'] ) )
-		//~ {
-			//~ $new_field_value = $meta['site_category'];
-			//~ update_option( 'site_category', $new_field_value );
-		//~ }
-	//~ }
-
-
-
-	/**
-	 * Add new field in site signup form /wp-signup.php
-	 *
-	 * URI: http://wordpress.stackexchange.com/a/50550/12615
-	 */
-	//~ public function signup_blogform_extra_field()
-	//~ {
-		//~ $txt = __( 'Category' );
-		//~ echo "
-		//~ <label>{$txt}</label>
-		//~ <input type='text' name='site_category' value='' />
-	//~ ";
-	//~ }
-	
-	
-	/**
-	 * Append the submitted value of our custom input 
-	 * into the meta array that is stored while the user doesn't activate
-	 *
-	 * URI: http://wordpress.stackexchange.com/a/50550/12615
-	 */
-	//~ public function append_extra_field_as_meta( $meta )
-	//~ {
-		//~ if( isset( $_REQUEST['site_category'] ) )
-			//~ $meta['site_category'] = $_REQUEST['site_category'];
-	//~ 
-		//~ return $meta;
-	//~ }
 
     /**
      * Tell WP all Matures are equal to 0
@@ -346,7 +282,7 @@ HTML;
     public function get_dropdown( $site_id )
     {
         $all_cats = get_option( self::$option_name );
-        $dropdown = '<select name="input_site_cat" id="input_site_cat">';
+        $dropdown = '<select name="blog[input_site_cat]" id="input_site_cat">';
         $site_cat = !empty( $site_id ) ? get_blog_option( $site_id, 'site_category' ) : false;
         $empty_cat = '';
         if( $site_cat )

--- a/multisite-site-category.php
+++ b/multisite-site-category.php
@@ -8,7 +8,7 @@
  * Original author: Rodolfo Buaiz
  * Maintainer: Trinh Nguyen
  * Maintainer URI: http://me.dangtrinh.com
- * Version: 2.00
+ * Version: 10.001
  * License: GPLv2 or later
  * 
  */
@@ -202,6 +202,8 @@ class B5F_Multisite_Categories
         );
         # Workaround to remove the suffix "-master" from the unzipped directory
         add_filter( 'upgrader_source_selection', array( $this, 'rename_github_zip' ), 1, 3 );
+        
+		add_action('wpmu_new_blog', array( $this, 'add_new_blog_field' ));
     }
 
 
@@ -212,6 +214,33 @@ class B5F_Multisite_Categories
      * @since 2012.09.12
      */
     public function __construct() {}
+
+
+     /**
+	* Add new option when registering a site (back and front end)
+	*
+	* URI: http://stackoverflow.com/a/10372861/1287812
+	*/
+	public function add_new_blog_field( $blog_id, $user_id, $domain, $path, $site_id, $meta )
+	{
+		$new_field_value = 'default';
+	
+		// Site added in the back end
+		if( !empty( $_POST['blog']['site_category'] ) )
+		{
+			switch_to_blog( $blog_id );
+			$new_field_value = $_POST['blog']['site_category'];
+			update_option( 'site_category', $new_field_value );
+		
+			restore_current_blog();
+		}
+		// Site added in the front end
+		elseif( !empty( $meta['site_category'] ) )
+		{
+			$new_field_value = $meta['site_category'];
+			update_option( 'site_category', $new_field_value );
+		}
+	}
 
 
     /**

--- a/multisite-site-category.php
+++ b/multisite-site-category.php
@@ -5,9 +5,10 @@
  * Plugin URI: https://github.com/brasofilo/multisite-site-category
  * Description: Add a custom meta option when registering new sites in WordPress Multisite.
  * Network: true
- * Author: Rodolfo Buaiz
- * Author URI: http://rodbuaiz.com/
- * Version: 2013.10.11
+ * Original author: Rodolfo Buaiz
+ * Maintainer: Trinh Nguyen
+ * Maintainer URI: http://me.dangtrinh.com
+ * Version: 2.00
  * License: GPLv2 or later
  * 
  */
@@ -15,6 +16,7 @@
 /*
 Multisite Site Category
 Copyright (C) 2013  Rodolfo Buaiz
+Copyright (C) 2015 Trinh Nguyen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/multisite-site-category.php
+++ b/multisite-site-category.php
@@ -170,8 +170,12 @@ class B5F_Multisite_Categories
         
         # SIGNUP FIELDS
         # needs further work, disable for now
-        // require_once 'inc/class-sites-categories-signup.php';
-        // new B5F_Sites_Categories_Signup();
+        require_once 'inc/class-sites-categories-signup.php';
+        new B5F_Sites_Categories_Signup();
+        
+		//~ if( !is_admin() ){
+			//~ add_action('signup_blogform', array( $this, 'signup_blogform_extra_field' ));
+		//~ }
         
         # WP, ALL MATURES ARE OK
         if( 'sites.php' != $pagenow )
@@ -203,7 +207,9 @@ class B5F_Multisite_Categories
         # Workaround to remove the suffix "-master" from the unzipped directory
         add_filter( 'upgrader_source_selection', array( $this, 'rename_github_zip' ), 1, 3 );
         
-		add_action('wpmu_new_blog', array( $this, 'add_new_blog_field' ));
+		//~ add_action('wpmu_new_blog', array( $this, 'add_new_blog_field' ));
+		//~ add_filter('add_signup_meta', array( $this, 'append_extra_field_as_meta'));
+		
     }
 
 
@@ -221,27 +227,57 @@ class B5F_Multisite_Categories
 	*
 	* URI: http://stackoverflow.com/a/10372861/1287812
 	*/
-	public function add_new_blog_field( $blog_id, $user_id, $domain, $path, $site_id, $meta )
-	{
-		$new_field_value = 'default';
-	
-		// Site added in the back end
-		if( !empty( $_POST['blog']['site_category'] ) )
-		{
-			switch_to_blog( $blog_id );
-			$new_field_value = $_POST['blog']['site_category'];
-			update_option( 'site_category', $new_field_value );
-		
-			restore_current_blog();
-		}
-		// Site added in the front end
-		elseif( !empty( $meta['site_category'] ) )
-		{
-			$new_field_value = $meta['site_category'];
-			update_option( 'site_category', $new_field_value );
-		}
-	}
+	//~ public function add_new_blog_field( $blog_id, $user_id, $domain, $path, $site_id, $meta )
+	//~ {
+		//~ $new_field_value = 'default';
+	//~ 
+		//~ // Site added in the back end
+		//~ if( !empty( $_POST['blog']['site_category'] ) )
+		//~ {
+			//~ switch_to_blog( $blog_id );
+			//~ $new_field_value = $_POST['blog']['site_category'];
+			//~ update_option( 'site_category', $new_field_value );
+		//~ 
+			//~ restore_current_blog();
+		//~ }
+		//~ // Site added in the front end
+		//~ elseif( !empty( $meta['site_category'] ) )
+		//~ {
+			//~ $new_field_value = $meta['site_category'];
+			//~ update_option( 'site_category', $new_field_value );
+		//~ }
+	//~ }
 
+
+
+	/**
+	 * Add new field in site signup form /wp-signup.php
+	 *
+	 * URI: http://wordpress.stackexchange.com/a/50550/12615
+	 */
+	//~ public function signup_blogform_extra_field()
+	//~ {
+		//~ $txt = __( 'Category' );
+		//~ echo "
+		//~ <label>{$txt}</label>
+		//~ <input type='text' name='site_category' value='' />
+	//~ ";
+	//~ }
+	
+	
+	/**
+	 * Append the submitted value of our custom input 
+	 * into the meta array that is stored while the user doesn't activate
+	 *
+	 * URI: http://wordpress.stackexchange.com/a/50550/12615
+	 */
+	//~ public function append_extra_field_as_meta( $meta )
+	//~ {
+		//~ if( isset( $_REQUEST['site_category'] ) )
+			//~ $meta['site_category'] = $_REQUEST['site_category'];
+	//~ 
+		//~ return $meta;
+	//~ }
 
     /**
      * Tell WP all Matures are equal to 0

--- a/multisite-site-category.php
+++ b/multisite-site-category.php
@@ -2,7 +2,7 @@
 
 /**
  * Plugin Name: Multisite Site Category
- * Plugin URI: https://github.com/brasofilo/multisite-site-category
+ * Plugin URI: https://github.com/dangtrinh/multisite-site-category.git
  * Description: Add a custom meta option when registering new sites in WordPress Multisite.
  * Network: true
  * Original author: Rodolfo Buaiz

--- a/multisite-site-category.php
+++ b/multisite-site-category.php
@@ -10,7 +10,7 @@
  * Maintainer URI: http://me.dangtrinh.com
  * Version: 2015.05.18
  * License: GPLv2 or later
- * 
+ * Network: True
  */
 
 /*


### PR DESCRIPTION
Wordpress 4.7+ deprecated the hook blog_details and replaced with site_details.

https://developer.wordpress.org/reference/hooks/blog_details/